### PR TITLE
Added support for Proxy in WS

### DIFF
--- a/azureiotdevice/azureiotdevice.html
+++ b/azureiotdevice/azureiotdevice.html
@@ -23,7 +23,9 @@
             caname: {value:""},
             cert: {type:"text", value: "", required:false},
             key: {type:"text", value: "", required:false},
-            ca: {type:"text", value:"", required: false}
+            ca: {type:"text", value:"", required: false},
+            proxy: {type:"http proxy",required: false,
+                    label:"Proxy Configuration" }
         },
         inputs:1,
         outputs:1,
@@ -175,6 +177,25 @@
                 }
             });
 
+            // Proxies
+            function updateProxyOptions() {
+                if ($("#node-input-useProxy").is(":checked")) {
+                    $("#node-input-useProxy-row").show();
+                } else {
+                    $("#node-input-useProxy-row").hide();
+                }
+                RED.tray.resize();
+            }
+            if (node.proxy) {
+                $("#node-input-useProxy").prop("checked", true);
+            } else {
+                $("#node-input-useProxy").prop("checked", false);
+            }
+            updateProxyOptions();
+            $("#node-input-useProxy").on("click", function() {
+                updateProxyOptions();
+            });
+
             // Direct methods
             let methodsItemCount = 0;
             if (node.methods && node.methods.length > 0) {
@@ -309,6 +330,9 @@
 
             // Save the DPS custom payload
             $("#node-input-DPSpayload").val(this.editor.getValue());
+            if (!$("#node-input-useProxy").is(":checked")) {
+                $("#node-input-proxy").val("_ADD_");
+            }
             this.editor.destroy();
             delete this.editor;
         },
@@ -403,6 +427,13 @@
                     <option value="mqtt">MQTT</option>
                     <option value="mqttWs">MQTT_WS</option>
                 </select>
+            </div>
+            <div class="form-row">
+                <input type="checkbox" id="node-input-useProxy" style="display: inline-block; width: auto; vertical-align: top;">
+                <label for="node-input-useProxy" style="width: auto;"><span>Use Proxy</span></label>
+                <div id="node-input-useProxy-row" class="hide">
+                    <label style="width: auto; margin-left: 20px; margin-right: 10px;" for="node-input-proxy"><i class="fa fa-globe"></i> <span>Proxy Configuration</span></label><input type="text" style="width: 270px" id="node-input-proxy">
+                </div>
             </div>
         </div>
         <div id="compact-device-tab-customDPS" style="display:none">

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "azure-iot-security-x509": "^1.8.0",
     "azure-iot-security-symmetric-key": "^1.8.0",
     "rhea": "^3.0.1",
-    "node-forge": "^1.3.1"
+    "node-forge": "^1.3.1",
+    "hpagent": "1.0.0"
   },
   "keywords": [
     "node-red",


### PR DESCRIPTION
Add support for Proxy configurations when using Websockets in both AMQP and MQTT. 

The confguration is done in a similar way to the Node-RED core `httprequest` node, and the implementation is carried out adding an `HttpsProxyAgent` as the `webSocketAgent` for both `amqpWs` and `mqttWs`. For that, the module `hpagent` is added to the `package.json`.